### PR TITLE
Support multiple slackUsernames

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,5 @@ jobs:
         SLACK_USERNAME: 'Capicapi'
         SLACK_GITHUB_USER_PAIRS: ${{ secrets.SLACK_USER }}
         TITLE: ':tada: Success :tada:'
-        BODY: 'ry-itto ry-itto ry-itto'
+        BODY: 'ry-itto github octocat'
 

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -51,5 +51,18 @@ describe('utils test', () => {
       )
       expect(result).toBe('`@ry-itto`')
     })
+
+    it('multiple slackUsernames', () => {
+      const slackUsernames = `
+      ry-itto,ito ryoya
+      github,octocat
+      `
+      const body = 'ry-itto and github'
+      const result = replaceGitHubUsernameWithSlackUsername(
+        body,
+        slackUsernames
+      )
+      expect(result).toBe('<@ito ryoya> and <@octocat>')
+    })
   })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,7 +106,7 @@ export const replaceGitHubUsernameWithSlackUsername = (
       if (!value) {
         return result
       }
-      result[key] = value
+      result[key.trim()] = value.trim()
       return result
     }, {}) ?? {}
   for (const [key, value] of Object.entries(githubToSlack)) {


### PR DESCRIPTION
solution of #5 

## Result
- Set multiple slackUsernames in `SLACK_USER` secret. Set same values to all keys.
```csv
ry-itto,XXXXXX
github,XXXXXX
octocat,XXXXX
```

- Body
```yaml
BODY: 'ry-itto github octocat'
```

- A message sent from GitHub Actions
<img width="400" alt="スクリーンショット 2021-02-26 22 53 40" src="https://user-images.githubusercontent.com/30540303/109308609-97575a80-7885-11eb-9884-1803a0d93422.png">
